### PR TITLE
[FEAT] 서치바 컴포저블 구현

### DIFF
--- a/app/src/main/java/com/example/sohaengsung/ui/components/Bookmark.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/Bookmark.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -28,7 +30,7 @@ fun Bookmark(
     onBookmarkToggle: (Boolean) -> Unit
 ) {
     var checked by remember { mutableStateOf(initialChecked) }
-    val icon = if (checked) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder // 채워진 아이콘 or 빈 아이콘
+    val icon = if (checked) Icons.Filled.Bookmark else Icons.Filled.BookmarkBorder // 채워진 아이콘 or 빈 아이콘
 
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/example/sohaengsung/ui/components/SearchBar.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/SearchBar.kt
@@ -1,0 +1,85 @@
+package com.example.sohaengsung.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.sohaengsung.ui.theme.SohaengsungTheme
+
+@Composable
+fun SearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onCalendarClick: () -> Unit
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange, // 텍스트 변경 이벤트 처리
+        placeholder = { Text("search event") },
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 56.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.secondary),
+
+        // 캘린더 아이콘
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Filled.CalendarMonth,
+                contentDescription = "행사 기간 선택",
+                tint = MaterialTheme.colorScheme.primary,
+                // 캘린더 아이콘 클릭 이벤트 처리
+                modifier = Modifier
+                    .clickable { onCalendarClick() }
+            )
+        },
+
+        // 검색 아이콘
+        trailingIcon = {
+            Icon(
+                imageVector = Icons.Filled.Search,
+                contentDescription = "검색",
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        },
+        singleLine = true
+    )
+}
+
+
+//@Preview(showBackground = true)
+//@Composable
+//fun PreviewSearchBar() {
+//    var searchText by remember { mutableStateOf("") }
+//
+//    SohaengsungTheme {
+//        SearchBar(
+//            query = searchText,
+//            onQueryChange = { newText ->
+//                searchText = newText // 텍스트 변경 시 상태 업데이트
+//                println("검색어 입력: $newText")
+//            },
+//            onCalendarClick = {
+//                // 캘린더 아이콘 클릭 시의 임시 로직
+//                println("캘린더 아이콘이 클릭되었습니다! 행사 기간을 선택하세요.")
+//            }
+//        )
+//    }
+//}

--- a/app/src/main/java/com/example/sohaengsung/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/theme/Color.kt
@@ -2,10 +2,10 @@ package com.example.sohaengsung.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
-
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+//val Purple80 = Color(0xFFD0BCFF)
+//val PurpleGrey80 = Color(0xFFCCC2DC)
+//val Pink80 = Color(0xFFEFB8C8)
+//
+//val Purple40 = Color(0xFF6650a4)
+//val PurpleGrey40 = Color(0xFF625b71)
+//val Pink40 = Color(0xFF7D5260)


### PR DESCRIPTION
# 관련 이슈
close #7

- 검색 이벤트, 캘린더 아이콘 클릭 시의 날짜 선택 이벤트는 추후 구현 예정입니다. (우선은 껍데기만)
```
@Composable
fun PreviewSearchBar() {
    var searchText by remember { mutableStateOf("") }

    SohaengsungTheme {
        SearchBar(
            query = searchText,
            onQueryChange = { newText ->
                searchText = newText // 텍스트 변경 시 상태 업데이트
                println("검색어 입력: $newText")
            },
            onCalendarClick = {
                // 캘린더 아이콘 클릭 시의 임시 로직
                println("캘린더 아이콘이 클릭되었습니다! 행사 기간을 선택하세요.")
            }
        )
    }
}
```