### PR TITLE
[FEAT] 탑바 컴포저블 구현 및 필요 의존성 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,11 @@ dependencies {
     // Icon
     implementation("androidx.compose.material:material-icons-extended")
 
+    // Compose Material 3
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material3:material3-window-size-class")
+    implementation("androidx.compose.material3:material3-adaptive-navigation-suite")
+
     // Navigation
     implementation("androidx.navigation:navigation-compose:2.8.3")
 

--- a/app/src/main/java/com/example/sohaengsung/ui/components/CustomTopBar.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/CustomTopBar.kt
@@ -1,0 +1,75 @@
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MediumTopAppBar
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.sohaengsung.ui.components.Dropdown
+import com.example.sohaengsung.ui.theme.SohaengsungTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomTopBar(contentText: String) {
+
+    // 그라데이션 색상 정의
+    val textGradientBrush = Brush.horizontalGradient(
+        listOf(
+            MaterialTheme.colorScheme.primary,   // 시작 색상
+            MaterialTheme.colorScheme.tertiary // 끝 색상
+        )
+    )
+
+    MediumTopAppBar(
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.background,
+            titleContentColor = Color.Unspecified
+        ),
+        title = {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Text(
+                    text = contentText,
+                    style = androidx.compose.ui.text.TextStyle(
+                        brush = textGradientBrush,
+                        fontSize = MaterialTheme.typography.titleLarge.fontSize,
+                        fontWeight = MaterialTheme.typography.titleLarge.fontWeight
+                    )
+                )
+            }
+        }
+    )
+}
+
+// 테스트 코드
+//@Preview(showBackground = false)
+//@Composable
+//fun CustomTopBarPreview() {
+//    SohaengsungTheme {
+//        Scaffold(
+//            topBar = {
+//                CustomTopBar(contentText = "내 주변 장소 추천") // 임포트해서 재사용
+//            }
+//        ) { innerPadding ->
+//            Column(Modifier.padding(innerPadding)) {
+//                Dropdown(
+//                    label = "유형별",
+//                    items = listOf("카페", "스터디", "도서관", "야외"),
+//                    containerColor = MaterialTheme.colorScheme.primary,
+//                    contentColor = MaterialTheme.colorScheme.onPrimary
+//                )
+//            }
+//        }
+//    }
+//}

--- a/app/src/main/java/com/example/sohaengsung/ui/components/DropDown.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/DropDown.kt
@@ -73,7 +73,7 @@ fun DropdownButton(
 }
 
 @Composable
-fun SelectableDropdown(
+fun Dropdown(
     label: String, // 초기 내용 (유형별, 리뷰순)
     items: List<String>, // 선택 가능 리스트 (카페, 서점, 소품샵...)
     initialSelection: String? = null, // 초기 선택 값
@@ -118,17 +118,17 @@ fun SelectableDropdown(
     }
 }
 
-// 테스트 코드
-//@Preview(showBackground = true)
-//@Composable
-//fun SelectableDropdownPreview() {
-//    SohaengsungTheme {
-//        val typeList = listOf("카페", "스터디", "도서관", "야외")
-//        SelectableDropdown(
-//            label = "유형별",
-//            items = typeList,
-//            containerColor = MaterialTheme.colorScheme.primary,
-//            contentColor = MaterialTheme.colorScheme.onPrimary
-//        )
-//    }
-//}
+
+@Preview(showBackground = true)
+@Composable
+fun DropdownPreview() {
+    SohaengsungTheme {
+        val typeList = listOf("카페", "스터디", "도서관", "야외")
+        Dropdown(
+            label = "유형별",
+            items = typeList,
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary
+        )
+    }
+}

--- a/app/src/main/java/com/example/sohaengsung/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/theme/Type.kt
@@ -18,8 +18,8 @@ val Typography = Typography(
     ),
     titleLarge = TextStyle(
         fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
+        fontWeight = FontWeight.Bold,
+        fontSize = 25.sp,
         lineHeight = 28.sp,
         letterSpacing = 0.sp
     ),


### PR DESCRIPTION
close #9

- 필요한 의존성을 추가했습니다.
- Type.kt 내의 텍스트 스타일을 조정했습니다.
- 아래와 같은 형태로, scaffold 내에 넣어 쓰시면 됩니다.
  - scaffold의 content 내부에 해시태그, 드롭다운 등의 타 컴포저블을 배치해 사용합니다.
```
@Composable
fun CustomTopBarPreview() {
    SohaengsungTheme {
        Scaffold(
            topBar = {
                CustomTopBar(contentText = "내 주변 장소 추천") // 임포트해서 재사용
            }
        ) { innerPadding ->
            Column(Modifier.padding(innerPadding)) {
                Dropdown(
                    label = "유형별",
                    items = listOf("카페", "스터디", "도서관", "야외"),
                    containerColor = MaterialTheme.colorScheme.primary,
                    contentColor = MaterialTheme.colorScheme.onPrimary
                )
            }
        }
    }
}
```