### PR TITLE
[FEAT] 컴포저블 추가 및 장소 관련 화면 임시 구현

### DIFF
--- a/app/src/main/java/com/example/sohaengsung/ui/components/CustomBottomSheet.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/CustomBottomSheet.kt
@@ -1,0 +1,40 @@
+package com.example.sohaengsung.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun CustomBottomSheet(
+    showSheet: Boolean, // 열림/닫힘 상태를 외부에서 받아 옴
+    onDismiss: () -> Unit, // 닫힘 이벤트를 외부로 전달
+    content: @Composable () -> Unit, // 내부 콘텐츠를 슬롯으로 받아 옴
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    if (showSheet) { // true일 때만 렌더링
+        ModalBottomSheet(
+            onDismissRequest = onDismiss, // 닫힘 요청 시 외부에서 전달받은 onDismiss를 호출
+            sheetState = sheetState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = MaterialTheme.colorScheme.background)
+        ) {
+            // 외부에서 전달된 content 컴포저블을 여기에 표시함
+            Column(modifier = Modifier
+                .fillMaxWidth()
+            ) {
+                content() // CustomBottomSheet의 content 슬롯
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/sohaengsung/ui/components/CustomContainer.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/CustomContainer.kt
@@ -1,0 +1,30 @@
+package com.example.sohaengsung.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CustomContainer(
+    content: @Composable () -> Unit // 내부 콘텐츠를 슬롯으로 받아 옴
+) {
+    // 기존 바텀 시트 -> 일반 컨테이너
+    Surface(
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp), // 상단 모서리만 둥글게
+        color = MaterialTheme.colorScheme.background,
+        shadowElevation = 8.dp // 그림자 효과
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/example/sohaengsung/ui/components/CustomDivider.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/CustomDivider.kt
@@ -1,0 +1,23 @@
+package com.example.sohaengsung.ui.components
+
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CustomDivider(
+    color: Color
+) {
+    HorizontalDivider(
+        Modifier
+            .fillMaxWidth() // 가로 전체를 채웁니다.
+            .padding(horizontal = 16.dp, vertical = 8.dp), // 좌우 패딩은 없애고 상하 패딩으로 간격 조절
+        1.dp,
+        color = color
+    )
+}

--- a/app/src/main/java/com/example/sohaengsung/ui/components/DropDown.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/DropDown.kt
@@ -119,16 +119,16 @@ fun Dropdown(
 }
 
 
-@Preview(showBackground = true)
-@Composable
-fun DropdownPreview() {
-    SohaengsungTheme {
-        val typeList = listOf("카페", "스터디", "도서관", "야외")
-        Dropdown(
-            label = "유형별",
-            items = typeList,
-            containerColor = MaterialTheme.colorScheme.primary,
-            contentColor = MaterialTheme.colorScheme.onPrimary
-        )
-    }
-}
+//@Preview(showBackground = false)
+//@Composable
+//fun DropdownPreview() {
+//    SohaengsungTheme {
+//        val typeList = listOf("카페", "스터디", "도서관", "야외")
+//        Dropdown(
+//            label = "유형별",
+//            items = typeList,
+//            containerColor = MaterialTheme.colorScheme.primary,
+//            contentColor = MaterialTheme.colorScheme.onPrimary
+//        )
+//    }
+//}

--- a/app/src/main/java/com/example/sohaengsung/ui/components/Hashtag.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/Hashtag.kt
@@ -29,7 +29,8 @@ fun Hashtag(content: String,
             text = content,
             style = MaterialTheme.typography.labelLarge,
             color = contentColor, // 글자 색
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
+            modifier = Modifier
+                .padding(horizontal = 12.dp, vertical = 4.dp)
         )
     }
 }

--- a/app/src/main/java/com/example/sohaengsung/ui/components/HashtagContainer.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/HashtagContainer.kt
@@ -1,0 +1,62 @@
+package com.example.sohaengsung.ui.components
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.sohaengsung.data.model.Hashtag
+import kotlin.collections.map
+
+@Composable
+fun HashtagListContainer(HashtagList01: List<Hashtag>, HashtagList02: List<Hashtag>) {
+    Column(
+        modifier = Modifier
+            .padding(vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+
+        // 해시태그 첫 번째 줄
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()), // 가로 스크롤 가능
+            horizontalArrangement = Arrangement.spacedBy(8.dp), // 8.dp 간격으로 해시태그 배치
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // HashtagListExample을 map으로 분해하여 Hashtag 컴포저블에 배치
+            HashtagList01.map { hashtagData ->
+                Hashtag(
+                    content = "#${hashtagData.name}", // 해시태그 이름 앞에 # 붙이기
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+        }
+
+        // 해시태그 두 번째 줄
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()), // 가로 스크롤 가능
+            horizontalArrangement = Arrangement.spacedBy(8.dp), // 8.dp 간격으로 해시태그 배치
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // HashtagListExample을 map으로 분해하여 Hashtag 컴포저블에 배치
+            HashtagList02.map { hashtagData ->
+                Hashtag(
+                    content = "#${hashtagData.name}", // 해시태그 이름 앞에 # 붙이기
+                    containerColor = MaterialTheme.colorScheme.tertiary,
+                    contentColor = MaterialTheme.colorScheme.onTertiary
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/sohaengsung/ui/components/PlaceDetailContainer.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/PlaceDetailContainer.kt
@@ -1,0 +1,81 @@
+package com.example.sohaengsung.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.sohaengsung.data.model.Place
+import com.example.sohaengsung.data.model.PlaceDetail
+
+fun Boolean.toOXString(): String = if (this) "O" else "X"
+
+@Composable
+fun PlaceDetailContainer(place: Place) {
+    Column (
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp)
+    ) {
+        // 장소 이름
+        Text(
+            text = place.name,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+
+        // 장소 해시태그
+        Text(
+            // PlaceExample.hashtags의 모든 아이템에 "#"와 공백을 붙여 하나의 문자열로 결합
+            text = place.hashtags.joinToString(separator = " ") { hashtag ->
+                "#$hashtag"
+            },
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        // 별점, 리뷰 개수
+        Text(
+            text = "⭐️ ${place.rating} (리뷰 ${place.reviewCount}개)",
+            style = MaterialTheme.typography.labelSmall
+        )
+
+        // 디테일 영역
+        Column(
+            modifier = Modifier.padding(top = 16.dp), // 상단 여백 추가
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            // 1. 와이파이 정보
+            Text(
+                text = "- 와이파이 제공 여부: ${place.details.wifi.toOXString()}",
+                style = MaterialTheme.typography.labelSmall
+            )
+
+            // 2. 주차 정보
+            Text(
+                text = "- 주차 가능 여부: ${place.details.parking.toOXString()}",
+                style = MaterialTheme.typography.labelSmall
+            )
+
+            // 3. 키즈존 정보
+            Text(
+                text = "- 키즈존 여부: ${place.details.kidsZone.toOXString()}",
+                style = MaterialTheme.typography.labelSmall
+            )
+
+            // 4. 시그니처 메뉴 정보 (null이 아닐 경우에만 표시)
+            place.details.signatureMenu?.let { menu ->
+                Text(
+                    text = "- 시그니처 메뉴: $menu",
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/sohaengsung/ui/components/PlaceInfoContainer.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/components/PlaceInfoContainer.kt
@@ -1,0 +1,56 @@
+package com.example.sohaengsung.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.sohaengsung.data.model.Place
+
+@Composable
+fun PlaceInfoContainer(place: Place) {
+        Column (
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(3.dp)
+        ) {
+            // 장소 이름
+            Text(
+                text = place.name,
+                style = MaterialTheme.typography.bodyLarge
+            )
+
+            // 장소 해시태그
+            Text(
+                // PlaceExample.hashtags의 모든 아이템에 "#"와 공백을 붙여 하나의 문자열로 결합
+                text = place.hashtags.joinToString(separator = " ") { hashtag ->
+                    "#$hashtag"
+                },
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary
+            )
+
+            // 별점, 리뷰 개수
+            Text(
+                text = "⭐️ ${place.rating} (리뷰 ${place.reviewCount}개)",
+                style = MaterialTheme.typography.labelSmall
+            )
+
+            // 임시 사진 영역
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(150.dp)
+                    .background(MaterialTheme.colorScheme.secondary),
+            )
+
+            CustomDivider(MaterialTheme.colorScheme.secondary)
+        }
+    }

--- a/app/src/main/java/com/example/sohaengsung/ui/screens/PlaceDetailScreen.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/screens/PlaceDetailScreen.kt
@@ -1,0 +1,84 @@
+package com.example.sohaengsung.ui.screens
+
+import android.R.attr.fontWeight
+import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.sohaengsung.data.model.Place
+import com.example.sohaengsung.data.model.PlaceDetail
+import com.example.sohaengsung.ui.components.CustomBottomSheet
+import com.example.sohaengsung.ui.components.CustomDivider
+import com.example.sohaengsung.ui.components.PlaceDetailContainer
+
+
+// 스크린이 아닌 컴포저블 형태로 PlaceRecommendScreen 안에 배치해야 할 수도?
+@Preview(showBackground = false)
+@Composable
+fun PlaceDetailScreen() {
+
+    // 바텀 시트의 열림/닫힘 상태
+    var isSheetOpen by remember { mutableStateOf(false) }
+    val PlaceExample = Place(
+        "00",
+        "올웨이즈어거스트제작소",
+        "망원동 00길 00번지",
+        hashtags = listOf("공부하기좋은", "따뜻한"),
+        details = PlaceDetail(
+            true,
+            true,
+            true,
+            "크림 라떼"
+        )
+    )
+
+    Column(modifier = Modifier.padding(16.dp)) {
+
+        // 임시 바텀 시트 열기 버튼
+        // 추후 이전 페이지에서 장소 컴포넌트 클릭 시 열도록 수정 예정
+        Button(onClick = { isSheetOpen = true }) {
+            Text("바텀 시트 열기")
+        }
+
+        CustomBottomSheet(
+            showSheet = isSheetOpen, // 현재 상태 전달
+            onDismiss = { isSheetOpen = false } // 닫힘 이벤트 처리
+        ) {
+
+            // 실제 내부에 들어갈 컨텐츠
+
+            // 1. 장소 상세 정보 컨테이너에 장소 객체 할당해서 가져 옴
+            PlaceDetailContainer(PlaceExample)
+
+            // 2. Divider
+            CustomDivider(MaterialTheme.colorScheme.secondary)
+
+            // 3. ReviewContainer
+            // 임시 리뷰 영역으로 대체
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(150.dp)
+                    .background(MaterialTheme.colorScheme.secondary),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/sohaengsung/ui/screens/PlaceRecommendScreen.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/screens/PlaceRecommendScreen.kt
@@ -1,0 +1,134 @@
+package com.example.sohaengsung.ui.screens
+
+import CustomTopBar
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.sohaengsung.data.model.Hashtag
+import com.example.sohaengsung.data.model.Place
+import com.example.sohaengsung.data.model.PlaceDetail
+import com.example.sohaengsung.ui.components.CustomContainer
+import com.example.sohaengsung.ui.components.Dropdown
+import com.example.sohaengsung.ui.components.HashtagListContainer
+import com.example.sohaengsung.ui.components.PlaceInfoContainer
+import com.example.sohaengsung.ui.theme.SohaengsungTheme
+
+
+@Preview(showBackground = false)
+@Composable
+fun PlaceRecommendScreen() {
+
+    // 예시용 임시 데이터
+    val HashtagListExample = listOf(
+        Hashtag(
+            tagId = "h001",
+            name = "공부하기좋은",
+            useCount = 125
+        ),
+        Hashtag(
+            tagId = "h002",
+            name = "따뜻한분위기",
+            useCount = 98
+        ),
+        Hashtag(
+            tagId = "h003",
+            name = "노트북콘센트",
+            useCount = 75
+        ),
+        Hashtag(
+            tagId = "h004",
+            name = "주차가능",
+            useCount = 52
+        )
+    )
+
+    val PlaceExample = Place(
+        "00",
+        "올웨이즈어거스트제작소",
+        "망원동 00길 00번지",
+        hashtags = listOf("공부하기좋은", "따뜻한"),
+        details = PlaceDetail(
+            true,
+            true,
+            true,
+            "크림 라떼"
+        )
+    )
+
+    SohaengsungTheme {
+        Scaffold(
+            topBar = {
+                CustomTopBar(contentText = "내 주변 장소 추천") // 임포트해서 재사용
+            }
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                // 지도 컴포넌트 임시 영역
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(300.dp) // 높이 임의 설정 중
+                        .background(MaterialTheme.colorScheme.secondary),
+                )
+                {
+                    Column (
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .padding(horizontal = 8.dp),
+                        verticalArrangement = Arrangement.SpaceBetween
+                    ) {
+
+                        // 해시태그 영역
+                        HashtagListContainer(
+                            HashtagListExample,
+                            HashtagListExample
+                        )
+
+                        // 드롭다운 영역
+                        Row(
+                            modifier = Modifier
+                                .padding(vertical = 8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Dropdown(
+                                label = "유형별",
+                                items = listOf("카페", "스터디", "도서관", "야외"),
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary
+                            )
+
+                            Dropdown(
+                                label = "유형별",
+                                items = listOf("카페", "스터디", "도서관", "야외"),
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary
+                            )
+                        }
+                    }
+                }
+
+                // 커스텀 컨테이너 안에 map 사용해서 장소 정보 PlaceInfoContainer 형태로 하나씩 배치 예정
+                CustomContainer() {
+                    PlaceInfoContainer(PlaceExample)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/sohaengsung/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/sohaengsung/ui/theme/Type.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.unit.sp
 val Typography = Typography(
     bodyLarge = TextStyle(
         fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
+        fontWeight = FontWeight.Bold,
         fontSize = 16.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
@@ -32,7 +32,7 @@ val Typography = Typography(
     ),
     labelSmall = TextStyle(
         fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Medium,
+        fontWeight = FontWeight.Normal,
         fontSize = 11.sp,
         lineHeight = 16.sp,
         letterSpacing = 0.5.sp


### PR DESCRIPTION
# 관련 이슈
close #12, close #13
   
# 커밋 내용
## `PlaceRecommendScreen` 관련
- 테스트용 예시 데이터를 임의로 작성하였습니다. 
- 지도, 사진 컴포넌트 대신 `Box`를 사용해 임시로 공간을 빼 두었습니다. 추후 수정 예정입니다.
  - 현재 `Place`와 `Review` 데이터에 사진 항목이 빠져 있습니다. 수정이 필요할 듯합니다.
- 화면 상단의 해시태그 두 줄은 아래와 같이 `HashtagListContainer`로 따로 분리해 관리하고 있습니다.
```kotlin
HashtagListContainer(
  HashtagListExample,
  HashtagListExample
)
```
- 화면 하단의 바텀 시트 컴포넌트를 Surface로 제작한 전용 컴포넌트(`CustomContainer`)로 대체했습니다.
- `PlaceInfoContainer`를 따로 정의해, 하나의 장소의 정보를 담는 전용 컴포넌트를 마련했습니다. `Place` 객체를 매개변수로 받아 옵니다.
  - `CustomContainer` 안에 각각의 장소 컴포넌트를 `PlaceInfoContainer` 형태로 배치해 사용할 예정입니다.
  - ~~`PlaceInfoContainer` 내에 북마크가 빠져 있어, 추후 추가하도록 하겠습니다.~~ -> 완료
```kotlin
// 커스텀 컨테이너 안에 `forEach` 사용해서 장소 정보 PlaceInfoContainer 형태로 하나씩 배치 예정
CustomContainer() {
  PlaceInfoContainer(PlaceExample)
}
```
   
## `PlaceDetailScreen` 관련
- ~~현재 `Screen`으로 분류 중이나, 추후 `PlaceRecommendScreen` 내의 컴포넌트로 배치하게 될 가능성이 높을 것 같습니다. 작업 중 필요하다고 판단되는 경우 업데이트 진행하도록 하겠습니다.~~ -> 완료
- ~~임시로 열림/닫힘 버튼을 제작해 이벤트를 관리하고 있습니다. 추후 데이터 연동 시 이전 페이지에서 데이터를 받아와 로드하는 방식으로 수정할 에정입니다.~~ -> 완료
- `CustomBottomSheet` 내에 필요한 컴포넌트(장소 디테일 정보, 리뷰)를 불러와 사용하는 방식입니다.
- `PlaceDetailContainer` 내에서 장소 디테일 정보를 관리합니다. `Place` 객체를 매개변수로 받아 옵니다.
   
## 기타
- `CustomDivider` 컴포넌트를 정의했습니다. 컬러를 매개변수로 가져 옵니다.
```kotlin
CustomDivider(MaterialTheme.colorScheme.secondary)
```